### PR TITLE
Update 3.6-predicting-house-prices.Rmd

### DIFF
--- a/notebooks/3.6-predicting-house-prices.Rmd
+++ b/notebooks/3.6-predicting-house-prices.Rmd
@@ -146,7 +146,7 @@ for (i in 1:k) {
                 
   # Evaluate the model on the validation data
   results <- model %>% evaluate(val_data, val_targets, verbose = 0)
-  all_scores <- c(all_scores, results$mean_absolute_error)
+  all_scores <- c(all_scores, results$mae)
 }  
 ```
 


### PR DESCRIPTION
replace 'mean_absolute_error' for 'mae', did something change in the evaluate() or fit() function?